### PR TITLE
add wrapper script to set umask on downstream images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -100,6 +100,7 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
  echo "**** add qemu ****" && \
  curl -o \
  /usr/bin/qemu-aarch64-static -L \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -100,6 +100,7 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
  echo "**** add qemu ****" && \
  curl -o \
  /usr/bin/qemu-arm-static -L \

--- a/root/usr/bin/with-contenv
+++ b/root/usr/bin/with-contenv
@@ -1,0 +1,7 @@
+#! /bin/bash
+if [[ -f /var/run/s6/container_environment/UMASK ]] && [[ "$(pwdx $$)" =~ "/run/s6/services/" ]]; then
+  umask $(cat /var/run/s6/container_environment/UMASK)
+  /usr/bin/with-contenvb "$@"
+else
+  /usr/bin/with-contenvb "$@"
+fi


### PR DESCRIPTION
This needs testing, with-contenv is called by the service run script, the $$ spits out the pid of the parent process  and pwdx shows the current working directory for that process , so if it is an actual service and the UMASK env param is set it will kick in and everything run in that service file will have that umask.

This will be overridden by stuff that has that setting in the service file itself as it runs before the actual bash logic in that service file. 

Once built all downstream baseimages should be manually triggered to ensure a complete waterfall.