### PR TITLE
bump alpine for base building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9 as rootfs-stage
+FROM alpine:3.12 as rootfs-stage
 
 # environment
 ENV REL=bionic

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM alpine:3.9 as rootfs-stage
+FROM alpine:3.12 as rootfs-stage
 
 # environment
 ENV REL=bionic

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM alpine:3.9 as rootfs-stage
+FROM alpine:3.12 as rootfs-stage
 
 # environment
 ENV REL=bionic


### PR DESCRIPTION
Looks like 3.9 repos have issues, no reason not to use 3.12. 