### PR TITLE
add iproute2 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN \
  apk add --no-cache \
         bash \
         curl \
+        iproute2 \
         tzdata \
         xz
 
@@ -84,6 +85,7 @@ RUN \
  echo "**** install packages ****" && \
  apt-get install -y \
 	curl \
+	iproute2 \
 	tzdata && \
  echo "**** generate locale ****" && \
  locale-gen en_US.UTF-8 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -8,6 +8,7 @@ RUN \
  apk add --no-cache \
         bash \
         curl \
+        iproute2 \
         tzdata \
         xz
 
@@ -84,6 +85,7 @@ RUN \
  echo "**** install packages ****" && \
  apt-get install -y \
 	curl \
+	iproute2 \
 	tzdata && \
  echo "**** generate locale ****" && \
  locale-gen en_US.UTF-8 && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -8,6 +8,7 @@ RUN \
  apk add --no-cache \
         bash \
         curl \
+        iproute2 \
         tzdata \
         xz
 
@@ -84,6 +85,7 @@ RUN \
  echo "**** install packages ****" && \
  apt-get install -y \
 	curl \
+	iproute2 \
 	tzdata && \
  echo "**** generate locale ****" && \
  locale-gen en_US.UTF-8 && \


### PR DESCRIPTION
Add iproute2 package, allows to set mtu, disable ipv6, get macvlan ip, etc. inside the container

## Description:
I have a rather unique setup using macvlan to give my containers e. g. radarr, jackett, qbittorrent its own ipv4 in the lan subnet and then use policy based routing on the firewall to route all traffic over a wireguard vpn.

## Benefits of this PR and context:
It adds the iproute2 package which usually comes by default in several distros, it allows to do many network tasks like set the network adapter mtu needed for routing over wireguard/openvpn, disable ipv6, get local macvlan ip, set custom routes etc. Note that setting mtu on macvlan bridge driver in docker is not supported and thus only works inside the container.

## How Has This Been Tested?
I extended the containers with a custom-cont-init.d script to install the package and set mtu, however this only works while the policy based routing is not in place, as soon as watchtower upgrades the container the package is gone and apt update doesnt work as mtu is not set. I think the addition of iproute2 might benefit multiple useres, its about 2.5mb in size but should be compressed at <1mb so not bloat the image. I could setup a workaround to download the iproute2 package and dependencies on the docker host and add them to the container volume to install locally, but i think it would be a neat addition to the linuxserver base as it allows for much more network tasks.

Please tell me what you think about it.