### PR TITLE
add wrapper script to set umask on downstream images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -99,6 +99,7 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
  echo "**** add qemu ****" && \
  curl -o \
  /usr/bin/qemu-aarch64-static -L \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -99,6 +99,7 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
  echo "**** add qemu ****" && \
  curl -o \
  /usr/bin/qemu-arm-static -L \

--- a/root/usr/bin/with-contenv
+++ b/root/usr/bin/with-contenv
@@ -1,0 +1,7 @@
+#! /bin/bash
+if [[ -f /var/run/s6/container_environment/UMASK ]] && [[ "$(pwdx $$)" =~ "/run/s6/services/" ]]; then
+  umask $(cat /var/run/s6/container_environment/UMASK)
+  exec /usr/bin/with-contenvb "$@"
+else
+  exec /usr/bin/with-contenvb "$@"
+fi


### PR DESCRIPTION
Ref: 92c6e348cffd05ff4fd78c038f43877e7886ff85

https://github.com/linuxserver/docker-baseimage-ubuntu/pull/38

Using syntax from the bionic branch as it has updated slightly since the original commit (adding `exec`).