### PR TITLE
Fix retrieve token from dockerhub for docker-mods : Mods on dockerhub unusable

### DIFF
--- a/root/docker-mods
+++ b/root/docker-mods
@@ -12,11 +12,13 @@ if [ ! -f /usr/bin/curl ]; then
     ## Ubuntu
     apt-get update
     apt-get install --no-install-recommends -y \
-      curl
+      curl \
+      jq
   elif [ -f /sbin/apk ]; then
     # Alpine
     apk add --no-cache \
-      curl
+      curl \
+      jq
   fi
 fi
 
@@ -30,19 +32,14 @@ get_blob_sha () {
       --location \
       --request GET \
       --header "Authorization: Bearer $2" \
-      $3 |\
-      grep -A4 'layers' |\
-      grep -m1 'digest' |\
-      awk -F'"' '{print $4}'
+      $3 | jq -r '.layers[0].digest'
   else
     curl \
       --silent \
       --location \
       --request GET \
       --header "Authorization: Bearer $2" \
-      $3 |\
-      grep -m1 "blobSum" |\
-      awk -F'"' '{print $4}'
+      $3 | jq -r '.fsLayers[0].blobSum'
   fi
 }
 
@@ -101,8 +98,7 @@ for DOCKER_MOD in "${DOCKER_MODS[@]}"; do
     --silent \
     --header 'GET' \
     "${AUTH_URL}" \
-    | grep -m1 "token" \
-    | awk -F'"' '{print $4}' \
+    | jq -r '.token' \
   )"
   # Determine first and only layer of image
   SHALAYER=$(get_blob_sha "${MODE}" "${TOKEN}" "${MANIFEST_URL}")

--- a/root/docker-mods
+++ b/root/docker-mods
@@ -6,8 +6,8 @@ if [ -z ${DOCKER_MODS+x} ]; then
 fi
 
 # Check for curl
-if [ ! -f /usr/bin/curl ]; then
-  echo "[mod-init] Curl was not found on this system for Docker mods installing"
+if [ ! -f /usr/bin/curl ] || [ ! -f /usr/bin/jq ]; then
+  echo "[mod-init] Curl/JQ was not found on this system for Docker mods installing"
   if [ -f /usr/bin/apt ]; then
     ## Ubuntu
     apt-get update

--- a/root/docker-mods
+++ b/root/docker-mods
@@ -101,6 +101,7 @@ for DOCKER_MOD in "${DOCKER_MODS[@]}"; do
     --silent \
     --header 'GET' \
     "${AUTH_URL}" \
+    | grep -m1 "token" \
     | awk -F'"' '{print $4}' \
   )"
   # Determine first and only layer of image


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]





------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-ubuntu/blob/bionic/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
There is a problem when getting token from DockerHub for docker-mods. So mods hosted on Dockerhub are for now unusable

There is a missing grep in the curl instruction to retrieve the token from DockerHub
because the curl request return 4 fields

```
curl     --silent     --header 'GET'     "${AUTH_URL}"
{
 "token": "....",
 "access_token": "...",
 "expires_in": 300,
 "issued_at": "2021-05-07T02:42:01.633778362Z"
}
```



I do not know if this PR should be apply to others base-images or if you have a central point for docker-mod script

## Benefits of this PR and context:
The code instruction to retrieve token can now works

## How Has This Been Tested?
Yes

## Source / References:

